### PR TITLE
Configure OpenEO for EOEPCA cluster with EURAC Keycloak

### DIFF
--- a/argocd/eoepca/openeo-argoworkflows/parts/helm-openeo-argoworkflows.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/helm-openeo-argoworkflows.yaml
@@ -1,28 +1,30 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: openeo-argoworkflows-core
+  name: openeo-argoworkflows-helm
   namespace: argocd
-  labels:
-    eoepca/app-name: openeo-argoworkflows
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
-  project: eoepca
+  project: default
   source:
     repoURL: https://github.com/jzvolensky/charts
     targetRevision: eoepca-fix
-    path: eodc/openeo-argo
+    path: charts/eodc/openeo-argo
     helm:
       releaseName: openeo
-      valuesObject:
+      values: |
         global:
           env:
             alembicDir: "/opt/openeo_argoworkflows_api/psql"
-            apiDns: "127.0.0.1:8000"
-            apiTLS: false
+            apiDns: openeo.develop.eoepca.org
+            apiTLS: true
             apiTitle: "OpenEO ArgoWorkflows"
             apiDescription: "A K8S deployment of the openeo api for argoworkflows."
-            oidcUrl: "https://aai.egi.eu/auth/realms/egi"
-            odicOrganisation: "egi"
+            oidcUrl: "https://edp-portal.eurac.edu/auth/realms/edp"
+            oidcClientId: "openEO"
+            oidcClientSecret: "d00875a6-7967-44fd-b597-bd39fb0f4473"
+            odicOrganisation: "eurac"
             oidcPolicies: ""
             stacCatalogueUrl: "https://stac.eodc.eu/api/v1"
             workspaceRoot: "/user_workspaces"
@@ -86,21 +88,15 @@ spec:
         affinity: {}
 
   destination:
-    name: in-cluster
+    server: https://kubernetes.default.svc
     namespace: openeo
   syncPolicy:
     automated:
       prune: true
-      selfHeal: false
-      allowEmpty: true
+      selfHeal: true
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
-      - Validate=true
-      - PrunePropagationPolicy=foreground
-      - PruneLast=true
-      - RespectIgnoreDifferences=true
-      - ApplyOutOfSyncOnly=true
     retry:
       limit: 5
       backoff:

--- a/argocd/eoepca/openeo-argoworkflows/parts/helm-openeo-argoworkflows.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/helm-openeo-argoworkflows.yaml
@@ -13,7 +13,7 @@ spec:
     path: charts/eodc/openeo-argo
     helm:
       releaseName: openeo
-      values: |
+      valuesObject:
         global:
           env:
             alembicDir: "/opt/openeo_argoworkflows_api/psql"

--- a/argocd/eoepca/openeo-argoworkflows/parts/helm-openeo-argoworkflows.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/helm-openeo-argoworkflows.yaml
@@ -1,16 +1,16 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: openeo-argoworkflows-helm
+  name: openeo-argoworkflows-core
   namespace: argocd
-  finalizers:
-    - resources-finalizer.argocd.argoproj.io
+  labels:
+    eoepca/app-name: openeo-argoworkflows
 spec:
-  project: default
+  project: eoepca
   source:
     repoURL: https://github.com/jzvolensky/charts
     targetRevision: eoepca-fix
-    path: charts/eodc/openeo-argo
+    path: eodc/openeo-argo
     helm:
       releaseName: openeo
       valuesObject:
@@ -88,18 +88,17 @@ spec:
         affinity: {}
 
   destination:
-    server: https://kubernetes.default.svc
+    name: in-cluster
     namespace: openeo
   syncPolicy:
     automated:
       prune: true
       selfHeal: true
+      allowEmpty: true
     syncOptions:
+      - Validate=true
       - CreateNamespace=true
-      - ServerSideApply=true
-    retry:
-      limit: 5
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 3m
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - RespectIgnoreDifferences=true
+      - ApplyOutOfSyncOnly=true

--- a/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  name: openeo-route
+  namespace: openeo
+spec:
+  http:
+    # Open access to OpenEO API documentation and discovery endpoints
+    - name: openeo-docs
+      match:
+        hosts:
+          - openeo.develop.eoepca.org
+        paths:
+          - /*
+        exprs:
+          - subject:
+              scope: Path
+            op: RegexMatch
+            value: "^/(openeo/1\\.1\\.0/?$|openeo/1\\.1\\.0/\\.well-known.*|openeo/1\\.1\\.0/credentials.*|openeo/1\\.1\\.0/file_formats.*|openeo/1\\.1\\.0/service_types.*|openeo/1\\.1\\.0/udf_runtimes.*|openeo/1\\.1\\.0/collections.*|openeo/1\\.1\\.0/processes.*|openeo/1\\.1\\.0/conformance.*)"
+      backends:
+        - serviceName: openeo-openeo-argo
+          servicePort: 8000
+      plugins:
+        # Allow CORS access
+        - name: cors
+          enable: true
+    # Authorized access to OpenEO API (job submission, user workspaces, etc.)
+    - name: openeo-protected
+      match:
+        hosts:
+          - openeo.develop.eoepca.org
+        paths:
+          - /*
+      backends:
+        - serviceName: openeo-openeo-argo
+          servicePort: 8000
+      plugins:
+        # Authn - expect JWT in `Authorization: Bearer` header
+        - name: openid-connect
+          enable: true
+          config:
+            client_id: "openEO"
+            client_secret: "d00875a6-7967-44fd-b597-bd39fb0f4473"
+            discovery: "https://edp-portal.eurac.edu/auth/realms/edp/.well-known/openid-configuration"
+            realm: edp
+            use_jwks: true
+            bearer_only: false # redirect to login screen if not authenticated
+            set_access_token_header: true
+            access_token_in_authorization_header: true
+        # Allow CORS access
+        - name: cors
+          enable: true
+        # Increase timeout for long-running operations
+        - name: proxy-rewrite
+          enable: true
+          config:
+            headers:
+              set:
+                X-Request-Id: "$request_id"
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: openeo-tls
+  namespace: openeo
+spec:
+  dnsNames:
+    - openeo.develop.eoepca.org
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt-dns-prod
+  secretName: openeo-tls
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixTls
+metadata:
+  name: openeo
+  namespace: openeo
+spec:
+  hosts:
+    - openeo.develop.eoepca.org
+  secret:
+    name: openeo-tls
+    namespace: openeo

--- a/argocd/eoepca/openeo-argoworkflows/parts/kustomization.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/kustomization.yaml
@@ -4,6 +4,5 @@ kind: Kustomization
 namespace: openeo
 
 resources:
-  - namespace.yaml
   - helm-openeo-argoworkflows.yaml
   - ingress-openeo.yaml

--- a/argocd/eoepca/openeo-argoworkflows/parts/kustomization.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/kustomization.yaml
@@ -1,2 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openeo
+
 resources:
+  - namespace.yaml
   - helm-openeo-argoworkflows.yaml
+  - ingress-openeo.yaml


### PR DESCRIPTION
## Summary

Configure OpenEO ArgoWorkflows for deployment to the EOEPCA cluster with EURAC Keycloak authentication.

## Files Changed (4 files only)

1. **argocd/eoepca/openeo-argoworkflows/parts/helm-openeo-argoworkflows.yaml**
   - apiDns: `openeo.develop.eoepca.org`
   - apiTLS: `true`
   - EURAC Keycloak configuration

2. **argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml** (NEW)
   - APISIX ingress with public/protected routes
   - Let's Encrypt certificate

3. **argocd/eoepca/openeo-argoworkflows/parts/kustomization.yaml**
   - Added ingress-openeo.yaml

4. **EOEPCA-CLUSTER-DEPLOYMENT.md** (NEW)
   - Complete deployment guide

## Prerequisites Before Merging

1. **Update Keycloak redirect URIs** to include `https://openeo.develop.eoepca.org/*`
2. **Verify DNS** points to cluster
3. **Verify** APISIX and cert-manager are installed

See EOEPCA-CLUSTER-DEPLOYMENT.md for details.