### PR TITLE
Update OpenEO domain and fix configuration

### DIFF
--- a/argocd/eoepca/openeo-argoworkflows/parts/helm-openeo-argoworkflows.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/helm-openeo-argoworkflows.yaml
@@ -17,7 +17,7 @@ spec:
         global:
           env:
             alembicDir: "/opt/openeo_argoworkflows_api/psql"
-            apiDns: openeo.develop.eoepca.org
+            apiDns: openeo-eurac.develop.eoepca.org
             apiTLS: true
             apiTitle: "OpenEO ArgoWorkflows"
             apiDescription: "A K8S deployment of the openeo api for argoworkflows."
@@ -93,12 +93,11 @@ spec:
   syncPolicy:
     automated:
       prune: true
-      selfHeal: true
+      selfHeal: false
       allowEmpty: true
     syncOptions:
       - Validate=true
       - CreateNamespace=true
+      - ServerSideApply=true
       - PrunePropagationPolicy=foreground
       - PruneLast=true
-      - RespectIgnoreDifferences=true
-      - ApplyOutOfSyncOnly=true

--- a/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
@@ -10,7 +10,7 @@ spec:
     - name: openeo-docs
       match:
         hosts:
-          - openeo.develop.eoepca.org
+          - openeo-eurac.develop.eoepca.org
         paths:
           - /*
         exprs:
@@ -29,7 +29,7 @@ spec:
     - name: openeo-protected
       match:
         hosts:
-          - openeo.develop.eoepca.org
+          - openeo-eurac.develop.eoepca.org
         paths:
           - /*
       backends:
@@ -66,7 +66,7 @@ metadata:
   namespace: openeo
 spec:
   dnsNames:
-    - openeo.develop.eoepca.org
+    - openeo-eurac.develop.eoepca.org
   issuerRef:
     kind: ClusterIssuer
     name: letsencrypt-dns-prod
@@ -83,7 +83,7 @@ metadata:
   namespace: openeo
 spec:
   hosts:
-    - openeo.develop.eoepca.org
+    - openeo-eurac.develop.eoepca.org
   secret:
     name: openeo-tls
     namespace: openeo


### PR DESCRIPTION
## Summary

Update OpenEO configuration after PR #2 was merged.

## Changes

1. **Domain change**: `openeo.develop.eoepca.org` → `openeo-eurac.develop.eoepca.org`
   - Avoids conflict with VITO's instance
   - Distinguishes EURAC's EURAC-Keycloak deployment

2. **Fix syncPolicy**:
   - `selfHeal: true` → `false` (safer for production)
   - Added `ServerSideApply` sync option
   - Removed unnecessary options (`RespectIgnoreDifferences`, `ApplyOutOfSyncOnly`)

## Prerequisites

Update Keycloak redirect URIs to include:
- `https://openeo-eurac.develop.eoepca.org/*`

## Files Changed

- `argocd/eoepca/openeo-argoworkflows/parts/helm-openeo-argoworkflows.yaml`
- `argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml`