### PR TITLE
Fix OpenEO authentication - add explicit redirect_uri

### DIFF
--- a/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
@@ -44,6 +44,7 @@ spec:
             client_secret: "d00875a6-7967-44fd-b597-bd39fb0f4473"
             discovery: "https://edp-portal.eurac.edu/auth/realms/edp/.well-known/openid-configuration"
             realm: edp
+            redirect_uri: "https://openeo-eurac.develop.eoepca.org/apisix/redirect"
             use_jwks: true
             bearer_only: false # redirect to login screen if not authenticated
             set_access_token_header: true


### PR DESCRIPTION
## Summary

Fix 500 Internal Server Error after OAuth login by adding explicit `redirect_uri` to APISIX openid-connect plugin configuration.

## Issue

After PR #3 was deployed, authentication redirects to Keycloak successfully, but returns 500 error after login.

## Fix

Add explicit `redirect_uri` configuration to APISIX openid-connect plugin:
```yaml
redirect_uri: "https://openeo-eurac.develop.eoepca.org/apisix/redirect"
```

## Testing

After merging, test with:
```
https://openeo-eurac.develop.eoepca.org/openeo/1.1.0/me
```

Should redirect to login and return user info after authentication.

## Files Changed

- `argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml`